### PR TITLE
Added implementation + tests for context aware via injection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
             <version>1.0-alpha-1</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- web console dependencies -->
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -194,7 +194,7 @@
             <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.sling</groupId>
@@ -235,6 +235,18 @@
             <artifactId>johnzon-core</artifactId>
             <version>1.0.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.caconfig.api</artifactId>
+            <version>1.1.3-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.models.api</artifactId>
+            <version>1.3.6</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/apache/sling/caconfig/impl/ConfigurationBuilderImpl.java
+++ b/src/main/java/org/apache/sling/caconfig/impl/ConfigurationBuilderImpl.java
@@ -65,7 +65,7 @@ class ConfigurationBuilderImpl implements ConfigurationBuilder {
     private final String configName;
 
     private static final Logger log = LoggerFactory.getLogger(ConfigurationBuilderImpl.class);
-    
+
     public ConfigurationBuilderImpl(final Resource resource,
             final ConfigurationResolver configurationResolver,
             final ConfigurationResourceResolvingStrategy configurationResourceResolvingStrategy,
@@ -157,7 +157,7 @@ class ConfigurationBuilderImpl implements ConfigurationBuilder {
     private <T> Collection<T> getConfigResourceCollection(String configName, Class<T> clazz, Converter<T> converter) {
         if (this.contentResource != null) {
            validateConfigurationName(configName);
-           
+
            // get all possible colection parent config names
            Collection<String> collectionParentConfigNames = configurationPersistenceStrategy.getAllCollectionParentConfigNames(configName);
            List<Iterator<Resource>> resourceInheritanceChains = new ArrayList<>();
@@ -184,7 +184,7 @@ class ConfigurationBuilderImpl implements ConfigurationBuilder {
             return Collections.emptyList();
         }
     }
-    
+
     @SuppressWarnings("unchecked")
     private <T> T convert(final Iterator<Resource> resourceInhertianceChain, final Class<T> clazz, final Converter<T> converter,
             final String name, final boolean isCollection) {
@@ -224,15 +224,15 @@ class ConfigurationBuilderImpl implements ConfigurationBuilder {
             log.trace("+ Found config resource for context path " + contentResource.getPath() + ": " + configResource.getPath() + " "
                     + MapUtil.traceOutput(configResource.getValueMap()));
         }
-        
+
         // if no config resource found still check for overrides
         if (configResource == null && contentResource != null) {
             configResource = configurationOverrideMultiplexer.overrideProperties(contentResource.getPath(), name, (Resource)null, contentResource.getResourceResolver());
         }
-        
+
         return converter.convert(configResource, clazz, conversionName, isCollection);
     }
-    
+
     /**
      * Apply default values from configuration metadata (where no real data is present).
      * @param resource Resource
@@ -249,7 +249,7 @@ class ConfigurationBuilderImpl implements ConfigurationBuilder {
         }
         return new ConfigurationResourceWrapper(resource, new ValueMapDecorator(updatedMap));
     }
-    
+
     /**
      * Apply default values from configuration metadata (where no real data is present).
      * @param props Properties
@@ -337,7 +337,7 @@ class ConfigurationBuilderImpl implements ConfigurationBuilder {
             });
         }
     }
-    
+
     // --- ValueMap support ---
 
     @Override
@@ -369,7 +369,7 @@ class ConfigurationBuilderImpl implements ConfigurationBuilder {
             }
         }
     }
-    
+
     // --- Adaptable support ---
 
     @Override
@@ -394,7 +394,13 @@ class ConfigurationBuilderImpl implements ConfigurationBuilder {
             if (resource == null || clazz == ConfigurationBuilder.class) {
                 return null;
             }
-            return applyDefaultValues(resource, configName).adaptTo(clazz);
+            Resource defaultsAppliedResource = applyDefaultValues(resource, configName);
+
+            if(clazz==Resource.class){
+                return (T)defaultsAppliedResource;
+            }else{
+                return defaultsAppliedResource.adaptTo(clazz);
+            }
         }
     }
 

--- a/src/main/java/org/apache/sling/caconfig/impl/models/via/CAConfigViaProvider.java
+++ b/src/main/java/org/apache/sling/caconfig/impl/models/via/CAConfigViaProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.caconfig.impl.models.via;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.adapter.Adaptable;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.caconfig.ConfigurationBuilder;
+import org.apache.sling.caconfig.ConfigurationResolver;
+import org.apache.sling.caconfig.models.via.ContextAwareConfigResource;
+import org.apache.sling.models.annotations.ViaProviderType;
+import org.apache.sling.models.spi.ViaProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+@Component(immediate = true, service = ViaProvider.class)
+public class CAConfigViaProvider implements ViaProvider {
+
+    @Reference
+    private ConfigurationResolver configurationResolver;
+
+    @Override
+    public Class<? extends ViaProviderType> getType() {
+        return ContextAwareConfigResource.class;
+    }
+
+    @Override
+    public Object getAdaptable(Object original, String value) {
+
+        Resource resource = getResource(original);
+
+        if (isBlank(value) || resource == null) {
+            return ORIGINAL;
+        }
+
+        ConfigurationBuilder config = configurationResolver.get(resource);
+        Resource adaptable = config.name(value).asAdaptable(Resource.class);
+
+        return adaptable;
+    }
+
+    private Resource getResource(Object adaptable){
+        if (adaptable instanceof SlingHttpServletRequest) {
+            return ((SlingHttpServletRequest) adaptable).getResource();
+        }
+        if (adaptable instanceof Resource) {
+            return (Resource) adaptable;
+        }
+        if(adaptable instanceof Adaptable){
+            return ((Adaptable) adaptable).adaptTo(Resource.class);
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/apache/sling/caconfig/impl/models/via/CAConfigViaProviderTest.java
+++ b/src/test/java/org/apache/sling/caconfig/impl/models/via/CAConfigViaProviderTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.caconfig.impl.models.via;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.caconfig.ConfigurationBuilder;
+import org.apache.sling.caconfig.ConfigurationResolver;
+import org.apache.sling.caconfig.models.via.ContextAwareConfigResource;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertSame;
+import static org.apache.sling.caconfig.resource.impl.def.ConfigurationResourceNameConstants.PROPERTY_CONFIG_REF;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CAConfigViaProviderTest {
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    @Mock
+    private ConfigurationResolver configurationResolver;
+
+    @InjectMocks
+    private CAConfigViaProvider underTest;
+
+    private Resource site1Page1;
+
+    @Mock
+    private ConfigurationBuilder configurationBuilder;
+    @Mock
+    private Resource configResource;
+
+    @Before
+    public void setUp(){
+
+        context.addModelsForPackage("org.apache.sling.caconfig.example");
+
+        // content resources
+        context.build().resource("/content/site1", PROPERTY_CONFIG_REF, "/conf/content/site1");
+        site1Page1 = context.create().resource("/content/site1/page1");
+
+        when(configurationResolver.get(site1Page1)).thenReturn(configurationBuilder);
+        when(configurationBuilder.name(anyString())).thenReturn(configurationBuilder);
+        when(configurationBuilder.asAdaptable(Resource.class)).thenReturn(configResource);
+
+    }
+
+    @Test
+    public void test_getAdaptable(){
+        Resource adaptable = (Resource) underTest.getAdaptable(site1Page1, "testconfig");
+
+        verify(configurationBuilder, times(1)).name("testconfig");
+        verify(configurationBuilder, times(1)).asAdaptable(Resource.class);
+
+        assertNotNull(adaptable);
+        assertSame(configResource, adaptable);
+    }
+
+    @Test
+    public void test_getType(){
+        assertSame(ContextAwareConfigResource.class, underTest.getType());
+    }
+}


### PR DESCRIPTION
Makes the following possible:

`@Model(adaptables = {SlingHttpServletRequest.class, Resource.class}, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
public class SampleModel {

    @Via(type= ContextAwareConfigResource.class, value = "config")
    @ValueMapValue
    private String propertyTest;

    public String getPropertyTest() {
        return propertyTest;
    }
}`

Use via to point to context aware config resource, to inject valuemap values.
Tested it locally and works fine with latest versions.
What do you think?