### PR TITLE
SLING-11716 add caching in caconfig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+        	<groupId>org.osgi</groupId>
+        	<artifactId>org.osgi.service.metatype.annotations</artifactId>
+        	<scope>compile</scope>
+       	</dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.osgi</artifactId>
             <version>2.4.0</version>
@@ -126,7 +131,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.16.4</version>
+            <version>2.24.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -178,7 +183,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-            <version>3.2.2</version>
+            <version>3.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
* cache successful resolutions and avoid duplicate resolutions of the same resource (path) and cah 
* updates to a later version of the ResourceResolver API